### PR TITLE
fix/ removed bug on LIC2 and LIC7 where valid input throws exception

### DIFF
--- a/decide/src/main/java/group17/LicAnalyzer.java
+++ b/decide/src/main/java/group17/LicAnalyzer.java
@@ -81,8 +81,12 @@ public class LicAnalyzer {
      */
     public boolean lic2(InputHandler input) {
 
-        if (input.NUMPOINTS < 3 || input.NUMPOINTS > 100) {
-            throw new IllegalArgumentException("NUMPOINTS must be between 2 (inclusive) and 100 (inclusive)");
+        if (input.NUMPOINTS < 2 || input.NUMPOINTS > 100) {
+            throw new IllegalArgumentException("NUMPOINTS must be inside range [2, 100]");
+        }
+
+        if (input.NUMPOINTS == 2) {
+            return false;
         }
 
         if (input.EPSILON < 0 || input.EPSILON >= Math.PI) {
@@ -180,8 +184,12 @@ public class LicAnalyzer {
      */
     public boolean lic7(InputHandler input) {
 
-        if (input.NUMPOINTS < 3 || input.NUMPOINTS > 100) {
-            throw new IllegalArgumentException("NUMPOINTS must be between 3 (inclusive) and 100 (inclusive)");
+        if (input.NUMPOINTS < 2 || input.NUMPOINTS > 100) {
+            throw new IllegalArgumentException("NUMPOINTS must be inside range [2, 100]");
+        }
+
+        if (input.NUMPOINTS == 2) {
+            return false;
         }
 
         if (input.K_PTS < 1 || input.K_PTS > input.NUMPOINTS-2) {

--- a/decide/src/test/java/group17/LicAnalyzerTest.java
+++ b/decide/src/test/java/group17/LicAnalyzerTest.java
@@ -238,7 +238,7 @@ public class LicAnalyzerTest {
 
     @Test
     public void lic2TestInvalidNUMPOINTS() {
-        input.NUMPOINTS = 2;
+        input.NUMPOINTS = 1;
         input.X_COORD = new double[]{0.0, 0.0};
         input.Y_COORD = new double[]{0.0, 0.0};
         input.EPSILON = Math.PI / 4;


### PR DESCRIPTION
Removed a bug on LIC2 and LIC7 that would throw exception for NUMPOINTS = 2 and that is a valid input. The condition is not met should be treated as false LIC

closes #73 